### PR TITLE
Update Get-ScriptBlockText to handle missing #text property

### DIFF
--- a/PowerShell 4104/Analyze-PowerShellEvents.ps1
+++ b/PowerShell 4104/Analyze-PowerShellEvents.ps1
@@ -84,16 +84,27 @@ function Get-ScriptBlockText {
     
     try {
         $messageXml = [xml]$Event.ToXml()
-        $scriptBlockText = $messageXml.Event.EventData.Data | 
-            Where-Object { $_.Name -eq 'ScriptBlockText' } | 
-            Select-Object -ExpandProperty '#text'
+        $scriptBlockTextNode = $messageXml.Event.EventData.Data | 
+            Where-Object { $_.Name -eq 'ScriptBlockText' }
+        
+        if ($scriptBlockTextNode -eq $null) {
+            Write-Warning "ScriptBlockText node not found in event $($Event.RecordId)"
+            return $null
+        }
+        
+        $scriptBlockText = $scriptBlockTextNode.'#text'
+        
+        if ($scriptBlockText -eq $null) {
+            Write-Warning "ScriptBlockText is empty in event $($Event.RecordId)"
+            return $null
+        }
         
         return $scriptBlockText
     }
     catch {
         Write-Warning "Failed to extract ScriptBlock text from event $($Event.RecordId): $_"
         return $null
-    }
+    } 
 }
 
 function Analyze-Events {


### PR DESCRIPTION
Great project - I was testing it out locally and got the following error:

```
$results = Analyze-Events -Patterns $patterns -MaxEvents $MaxEvents
Select-Object: 
Line |
  10 |              Select-Object -ExpandProperty '#text'
     |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Property "#text" cannot be found.
```

Now I'd expect normally this would output the event that failed to load, given the try/catch:

```
function Get-ScriptBlockText {
    param (
        [System.Diagnostics.Eventing.Reader.EventRecord]$Event
    )
    
    try {
        $messageXml = [xml]$Event.ToXml()
        $scriptBlockText = $messageXml.Event.EventData.Data | 
            Where-Object { $_.Name -eq 'ScriptBlockText' } | 
            Select-Object -ExpandProperty '#text'
        
        return $scriptBlockText
    }
    catch {
        Write-Warning "Failed to extract ScriptBlock text from event $($Event.RecordId): $_"
        return $null
    } 
}
```

However as you can see, it just outputs the error message from `Select-Object`.

My $PSVersionTable info:

```
$PSVersionTable

Name                           Value
----                           -----
PSVersion                      7.4.6
PSEdition                      Core
GitCommitId                    7.4.6
Platform                       Win32NT
PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0…}       
PSRemotingProtocolVersion      2.3
SerializationVersion           1.1.0.1
WSManStackVersion              3.0
```

So in this case, it just throws an error at you when it finds the `ScriptBlockText` node in the event data, but if the `#text` property isn't there it errors out.

So this just fixes that issue by adding some simple checks - first we just check that the node exists (is not null), then we try to set a variable to the `#text` property and check if it's null. 

Might be a dumb fix, but it fixed the issue for me :)